### PR TITLE
Match push constants binding to upstream plume.

### DIFF
--- a/XenosRecomp/shader_recompiler.cpp
+++ b/XenosRecomp/shader_recompiler.cpp
@@ -1711,7 +1711,7 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
         out += "\tconstant Texture2DArrayDescriptorHeap* g_Texture2DArrayDescriptorHeap [[buffer(1)]],\n";
         out += "\tconstant TextureCubeDescriptorHeap* g_TextureCubeDescriptorHeap [[buffer(2)]],\n";
         out += "\tconstant SamplerDescriptorHeap* g_SamplerDescriptorHeap [[buffer(3)]],\n";
-        out += "\tconstant PushConstants& g_PushConstants [[buffer(4)]]\n";
+        out += "\tconstant PushConstants& g_PushConstants [[buffer(8)]]\n";
 
         out += "#else\n";
 
@@ -1729,7 +1729,7 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
     else
     {
         out += "#ifdef __air__\n";
-        out += "\tconstant PushConstants& g_PushConstants [[buffer(4)]],\n";
+        out += "\tconstant PushConstants& g_PushConstants [[buffer(8)]],\n";
         out += "\tVertexShaderInput input [[stage_in]]\n";
         out += "#else\n";
         out += "\tVertexShaderInput input\n";


### PR DESCRIPTION
Upstream does not have the change to reduce push constants space. We don't seem to need it from a quick glance anyway (but can revisit and coordinate getting that change finished in upstream if it turns out we do).