### PR TITLE
Do not include Windows min/max

### DIFF
--- a/XenosRecomp/pch.h
+++ b/XenosRecomp/pch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifdef _WIN32
+#define NOMINMAX
 #include <Windows.h>
 #endif
 


### PR DESCRIPTION
Fixes conflict with `std::max`.