### PR TITLE
Fix HLSL shader issues.

### DIFF
--- a/XenosRecomp/main.cpp
+++ b/XenosRecomp/main.cpp
@@ -142,7 +142,6 @@ int main(int argc, char** argv)
 
 #ifdef XENOS_RECOMP_AIR
                 shader.air = AirCompiler::compile(recompiler.out);
-                assert(shader.air != nullptr);
 #endif
 
                 IDxcBlob* spirv = dxcCompiler.compile(recompiler.out, recompiler.isPixelShader, false, true);
@@ -175,6 +174,8 @@ int main(int argc, char** argv)
             size_t shaderPos = filename.find("shader");
             if (shaderPos != std::string::npos) {
                 filename = filename.substr(shaderPos);
+                // Prevent bad escape sequences in Windows shader path.
+                std::replace(filename.begin(), filename.end(), '\\', '/');
             }
             f.println("\t{{ 0x{:X}, {}, {}, {}, {}, {}, {}, {}, \"{}\" }},",
                 hash, dxil.size(), (shader.dxil != nullptr) ? shader.dxil->GetBufferSize() : 0,

--- a/XenosRecomp/shader_common.h
+++ b/XenosRecomp/shader_common.h
@@ -41,7 +41,7 @@ struct PushConstants
 
 #define g_SpecConstants() g_SpecConstants
 
-#elif __air__
+#elif defined(__air__)
 
 #include <metal_stdlib>
 


### PR DESCRIPTION
* Fix bad checks for `__air__` and `__spirv__` flags.
* Fix incorrect definition of position input in pixel shaders. Must be in the struct like the output from the vertex shader.
* Fix bad shader file names in cache when compiled on Windows.
* Fix incorrect assert null check on a non-pointer that broke macOS debug build.

These changes fix shader issues under D3D12.