### PR TITLE
Speed up shader recompilation on macOS.

### DIFF
--- a/XenosRecomp/CMakeLists.txt
+++ b/XenosRecomp/CMakeLists.txt
@@ -34,13 +34,6 @@ target_precompile_headers(XenosRecomp PRIVATE pch.h)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(XenosRecomp PRIVATE -Wno-switch -Wno-unused-variable -Wno-null-arithmetic -fms-extensions)
-
-    include(CheckCXXSymbolExists)
-    check_cxx_symbol_exists(_LIBCPP_VERSION version LIBCPP)
-    if(LIBCPP)
-        # Allows using std::execution
-        target_compile_options(XenosRecomp PRIVATE -fexperimental-library)
-    endif()
 endif()
 
 if (WIN32)


### PR DESCRIPTION
* Switch back to `posix_spawn` and `waitpid` instead of `std::system`, as `std::system` was not working in parallel.
* Fix the original issue behind the slowness, which was that `std::execution::par_unseq` was not working to execute in parallel either. Instead, use a queue and a pool of threads sized based on available hardware concurrency.
* Remove experimental library compile flag since it was only needed for `std::execution::par_unseq`. 

This makes MSL shader compilation complete several times faster on my system.