### PR TITLE
Add specialization for conditional rendering.

### DIFF
--- a/XenosRecomp/air_compiler.cpp
+++ b/XenosRecomp/air_compiler.cpp
@@ -58,6 +58,9 @@ std::vector<uint8_t> AirCompiler::compile(const std::string& shaderSource)
 #ifdef UNLEASHED_RECOMP
         "-DUNLEASHED_RECOMP",
 #endif
+#ifdef MARATHON_RECOMP
+        "-DMARATHON_RECOMP",
+#endif
         nullptr
     };
     if (const int compileStatus = executeCommand(compileCommand); compileStatus != 0)

--- a/XenosRecomp/dxc_compiler.cpp
+++ b/XenosRecomp/dxc_compiler.cpp
@@ -62,6 +62,9 @@ IDxcBlob* DxcCompiler::compile(const std::string& shaderSource, bool compilePixe
 #ifdef UNLEASHED_RECOMP
     args[argCount++] = L"-DUNLEASHED_RECOMP";
 #endif
+#ifdef MARATHON_RECOMP
+    args[argCount++] = L"-DMARATHON_RECOMP";
+#endif
 
     IDxcResult* result = nullptr;
     HRESULT hr = dxcCompiler->Compile(&source, args, argCount, nullptr, IID_PPV_ARGS(&result));


### PR DESCRIPTION
Adds two specializations for shaders:
* Conditional Survey: If enabled, the shader will increment a sample counter at the provided index in the conditional survey side buffer.
* Conditional Rendering: If enabled, the shader will test the provided index in the conditional survey buffer to see if the sample count is greater than 0.

These are put behind a new `MARATHON_RECOMP` to denote our game-specific shader logic.

In order to make surveying work, this also adds early fragment test optimization to shaders that don't write depth, meaning the depth/etc tests will be performed before the fragment shader is invoked.